### PR TITLE
added monadic testing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# reflex-test-app
+# reflex-test-host
 
 This library contains functionality for writing unit tests for the "model" portion of your reflex-frp apps. Please see `test/Reflex/Test/App.hs` for basic usage example. You can find more usage examples in [this project](https://github.com/pdlla/reflex-potatoes?files=1) and [this one](https://github.com/pdlla/reflex-todo-undo-mvc-model).
 

--- a/package.yaml
+++ b/package.yaml
@@ -73,6 +73,7 @@ dependencies:
 - lens
 - transformers
 - mtl
+- primitive
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -70,6 +70,8 @@ dependencies:
 - ref-tf
 - dependent-sum
 - these
+- lens
+- transformers
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -72,6 +72,7 @@ dependencies:
 - these
 - lens
 - transformers
+- mtl
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -77,6 +77,7 @@ library:
   source-dirs: src
   exposed-modules:
     - Reflex.Test.Host
+    - Reflex.Test.Monad.Host
 
 tests:
   reflex-test-host-test:

--- a/src/Reflex/Test/Host.hs
+++ b/src/Reflex/Test/Host.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 
+-- TODO rename to SimpleHost
 -- |
 -- Module:
 --   Reflex.Test.Host

--- a/src/Reflex/Test/Host.hs
+++ b/src/Reflex/Test/Host.hs
@@ -9,7 +9,7 @@
 
 module Reflex.Test.Host
   ( TestGuestConstraints
-  , TestGuestMonad
+  , TestGuestT
   , AppIn(..)
   , AppOut(..)
   , AppFrame(..)
@@ -37,6 +37,8 @@ import           Reflex
 import           Reflex.Host.Class
 
 
+type TestGuestT t (m :: Type -> Type) = PostBuildT t (PerformEventT t m)
+
 -- TODO some of these constraints can be dropped probably
 type TestGuestConstraints t (m :: Type -> Type)
   = ( MonadReflexHost t m
@@ -51,8 +53,6 @@ type TestGuestConstraints t (m :: Type -> Type)
     , MonadIO m
     , MonadFix m
     )
-
-type TestGuestMonad t (m :: Type -> Type) = PostBuildT t (PerformEventT t m)
 
 data AppIn t b e = AppIn
     { _appIn_behavior :: Behavior t b
@@ -78,7 +78,7 @@ data AppFrame t bIn eIn bOut eOut m = AppFrame
 getAppFrame
   :: forall t bIn eIn bOut eOut m
    . (TestGuestConstraints t m)
-  => (AppIn t bIn eIn -> TestGuestMonad t m (AppOut t bOut eOut))
+  => (AppIn t bIn eIn -> TestGuestT t m (AppOut t bOut eOut))
   -> bIn
   -> m (AppFrame t bIn eIn bOut eOut m)
 getAppFrame app b0 = do
@@ -157,7 +157,7 @@ tickAppFrame AppFrame {..} input = r where
 -- see comments for 'tickAppFrame'
 runApp
   :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (AppIn t bIn eIn -> TestGuestMonad t m (AppOut t bOut eOut))
+  => (AppIn t bIn eIn -> TestGuestT t m (AppOut t bOut eOut))
   -> bIn
   -> [Maybe (These bIn eIn)]
   -> IO [[(bOut, Maybe eOut)]]
@@ -171,7 +171,7 @@ runApp app b0 input = runSpiderHost $ do
 -- see comments for 'tickAppFrame'
 runAppSimple
   :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (Event t eIn -> TestGuestMonad t m (Event t eOut))
+  => (Event t eIn -> TestGuestT t m (Event t eOut))
   -> [eIn]
   -> IO [[Maybe eOut]]
 runAppSimple app input = runApp' app (map Just input)
@@ -180,7 +180,7 @@ runAppSimple app input = runApp' app (map Just input)
 -- see comments for 'tickAppFrame'
 runApp'
   :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (Event t eIn -> TestGuestMonad t m (Event t eOut))
+  => (Event t eIn -> TestGuestT t m (Event t eOut))
   -> [Maybe eIn]
   -> IO [[Maybe eOut]]
 runApp' app input = do
@@ -191,7 +191,7 @@ runApp' app input = do
 -- see comments for 'tickAppFrame'
 runAppB
   :: (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (Event t eIn -> TestGuestMonad t m (Behavior t bOut))
+  => (Event t eIn -> TestGuestT t m (Behavior t bOut))
   -> [Maybe eIn]
   -> IO [[bOut]]
 runAppB app input = do

--- a/src/Reflex/Test/Monad/Host.hs
+++ b/src/Reflex/Test/Monad/Host.hs
@@ -108,13 +108,13 @@ instance (MonadSubscribeEvent t m) => MonadSubscribeEvent t (ReflexTestM t inh o
 instance (MonadIO m) => MonadIO (ReflexTestM t inh out m) where
   liftIO = lift . liftIO
 
--- TODO make general version work
 runReflexTestM :: forall inh inev out t m a. (TestGuestConstraints t m)
-  => (inh, inev) -- ^ make sure inh match inputs, i.e. return values of newEventWithTriggerRef
+  -- TODO rename inh to intref or something
+  => (inev, inh) -- ^ make sure inh match inputs, i.e. return values of newEventWithTriggerRef
   -> (inev -> TriggerEventT t (PostBuildT t (PerformEventT t m)) out)
   -> ReflexTestM t inh out m a
   -> m ()
-runReflexTestM (inputH, input) app rtm = do
+runReflexTestM (input, inputH) app rtm = do
   (postBuild, postBuildTriggerRef) <- newEventWithTriggerRef
 
   events <- liftIO newChan
@@ -131,7 +131,7 @@ runReflexTestM (inputH, input) app rtm = do
 
 
   -- TODO figure out how to do this
-  -- correct solution is to implement non-blocking variant of TriggerEventT
+  -- one solution is to implement non-blocking variant of TriggerEventT
   -- and then pass as part of AppState such that each call to readPhase will fire any trigger events
   -- another option is just to start a thread and output warnings anytime triggerEvs are created
   --triggerEvs <- liftIO $ readChan events

--- a/src/Reflex/Test/Monad/Host.hs
+++ b/src/Reflex/Test/Monad/Host.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- TODO rename to SimpleHost
+-- |
+-- Module:
+--   Reflex.Test.Host
+-- Description:
+--   This module contains reflex host methods for testing without external events
+
+module Reflex.Test.Monad.Host
+  ( AppIn(..)
+  , AppOut(..)
+  , AppFrame(..)
+  , getAppFrame
+  , tickAppFrame
+  , runAppSimple
+  , runApp
+  , runApp'
+  , runAppB
+  )
+where
+
+import           Prelude
+
+import           Control.Monad
+import           Control.Monad.Ref
+import           Data.Dependent.Sum
+import           Data.Functor.Identity
+import           Data.Maybe            (fromJust)
+import           Data.These
+
+import           Reflex
+import           Reflex.Host.Class
+
+
+class MonadReflexTest m inh out where
+  inputEventHandles :: m inh -- ^ reads input event handles for use in calls to queueEvent
+  queueEventTrigger :: DSum (EventTrigger t) Identity -> m ()
+  outputs :: m out
+
+  -- TODO seems like you need to do fireQueuedEventsAndRead all at once :(
+  -- this means you don't get postbuild stuff unless you do something hacky like first call to this does postbuild...
+  readOutput :: ReadPhase (SpiderHost t) a -> m a
+  fireQueuedEvents :: m ()
+
+data AppState t = AppState {
+  _appState_queuedEvents :: [DSum (EventTrigger t) Identity] -- ^ events to fire in next 'FireCommand'
+  , _appState_fire :: FireCommand t (SpiderHost t) -- ^ 'FireCommand' to fire events and run next frame
+
+  -- TODO DELETE won't work, each call to readPhase fires events again
+  , _appState_readPhase :: forall a. ReadPhase (SpiderHost t) a -> SpiderHost t a -- ^ method to execute 'ReadPhase' from previous 'FireCommand' or from 'PostBuild' if no previously fired events
+}
+
+newtype ReflexTestM inh out t a = ReflexTestM { unReflexTestM :: (inh, out) -> AppState t -> SpiderHost t (AppState t, a) }
+
+instance Functor (ReflexTestM inh out t) where
+  fmap f ma = ReflexTestM $ \io as -> over _2 (fmap f) $ unReflexTestM ma io as
+
+instance Applicative (ReflexTestM inh out t) where
+  pure a = ReflexTestM $ \_ as -> return (as, a)
+  liftA2 f ma mb = ReflexTestM $ \io as0 -> r where
+    (as1, a) = unReflexTestM ma io as0
+    (as2, b) = unReflexTestM mb io as1
+    r = return (as2, f a b)
+
+instance Monad (ReflexTestM inh out t) where
+  (>>=) ma f = ReflexTestM $ \io as0 -> r where
+    (as1, a) = unReflexTestM ma io as0
+    r = unReflexTestM (f a) io as1
+
+instance MonadReflexTest (ReflexTestM inh in out t m) inh out where
+  inputEventHandles = ReflexTestM $ \(inh,_) as -> return (as, inh)
+  queueEventTrigger evt = ReflexTestM $ \_ as -> return (as { _appState_queuedEvents = evt : _appState_queuedEvents as}, ())
+  outputs = ReflexTestM $ \(_,out) as -> return (as, out)
+  readOutput rp = ReflexTestM $ \_ as -> fmap (as,) $ _appState_readPhase as rp
+  fireQueuedEvents = ReflexTestM $ \_ as -> return (as { _appState_readPhase = _appState_fire as (_appState_queuedEvents as) }, ())
+
+
+runReflexTestM ::
+  ReflextTestM inh in out t m a
+  -> (inh, in) -- ^ make sure inh match inputs, i.e. return values of newEventWithTriggerRef
+  -> (in -> TriggerEventT (PostBuildT (PerformEventT t m out)))
+  -> IO a
+runReflexTestM rtm (inputH, input) app = do
+  (postBuild, postBuildTriggerRef) <- newEventWithTriggerRef
+  events <- liftIO newChan
+  (output, fc@(FireCommand fire)) <- do
+    hostPerformEventT $
+      flip runPostBuildT postBuild $
+        flip runTriggerEventT events $
+          app input
+
+  mPostBuildTrigger <- readRef postBuildTriggerRef
+  rp0 <- case mPostBuildTrigger of
+    Nothing -> error "could not create PostBuild trigger ref"
+    Just postBuildTrigger -> fire [postBuildTrigger :=> Identity ()]
+
+
+  -- TODO figure out how to do this
+  -- correct solution is to implement non-blocking variant of TriggerEventT
+  -- and then pass as part of AppState such that each call to readPhase will fire any trigger events
+  -- another option is just to start a thread and output warnings anytime triggerEvs are created
+  --triggerEvs <- liftIO $ readChan events
+
+  unReflexTestM rtm (inputH, output) (AppState [] fc rp0)
+
+
+
+
+class ReflexTestApp inh in out app t m where
+  testApp :: in -> TriggerEventT (PostBuildT (PerformEventT t m out))
+  makeInputs :: SpiderHost t (inh, in)
+
+
+runReflexTestApp :: (ReflexTestApp inh in out app t m a) =>

--- a/src/Reflex/Test/Monad/Host.hs
+++ b/src/Reflex/Test/Monad/Host.hs
@@ -9,7 +9,7 @@
 --   This module contains reflex host methods for testing without external events
 
 module Reflex.Test.Monad.Host
-  ( ReflexHostT
+  ( TestGuestT
   , TestGuestConstraints
   , MonadReflexTest(..)
   , AppState(..)
@@ -35,9 +35,11 @@ import           Data.Kind
 import           Reflex
 import           Reflex.Host.Class
 
-type ReflexHostT t (m :: Type -> Type)
+
+type TestGuestT t (m :: Type -> Type)
   = TriggerEventT t (PostBuildT t (PerformEventT t m))
 
+-- TODO some of these constraints can be dropped probably
 type TestGuestConstraints t (m :: Type -> Type)
   = ( MonadReflexHost t m
     , MonadHold t m
@@ -124,7 +126,7 @@ runReflexTestM
   :: forall mintref inev out t m a
    . (TestGuestConstraints t m)
   => (inev, mintref) -- ^ make sure mintref match inev, i.e. return values of newEventWithTriggerRef
-  -> (inev -> ReflexHostT t m out) -- ^ network to test
+  -> (inev -> TestGuestT t m out) -- ^ network to test
   -> ReflexTestM t mintref out m a -- ^ test monad to run
   -> m ()
 runReflexTestM (input, inputTRefs) app rtm = do
@@ -165,7 +167,7 @@ class ReflexTestApp app t m | app -> t m where
   data AppInputTriggerRefs app :: Type
   data AppInputEvents app :: Type
   data AppOutput app :: Type
-  getApp :: AppInputEvents app -> ReflexHostT t m (AppOutput app)
+  getApp :: AppInputEvents app -> TestGuestT t m (AppOutput app)
   makeInputs :: m (AppInputEvents app, AppInputTriggerRefs app)
 -- TODO to simplify MonadReflexTest interface, maybe we could do something like
 -- subscribeEventsAndReturnTriggers :: m (AppInputTriggers app)

--- a/src/Reflex/Test/Monad/Host.hs
+++ b/src/Reflex/Test/Monad/Host.hs
@@ -65,7 +65,8 @@ class MonadReflexTest t m | m -> t  where
   type InputTriggerRefs m :: Type
   -- | in practice, this will likely be a record containing events and behaviors for the monad user to build a 'ReadPhase' that is passed into 'fireQueuedEventsAndRead'
   type OutputEvents m :: Type
-  -- TODO I think you can get rid of this
+  -- | the inner monad that reflex is running in
+  -- likely 'SpiderHost Global'
   type InnerMonad m :: Type -> Type
   -- | see comments for 'InputTriggerRefs'
   inputTriggerRefs :: m (InputTriggerRefs m)

--- a/src/Reflex/Test/Monad/Host.hs
+++ b/src/Reflex/Test/Monad/Host.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE RecordWildCards     #-}
 
 -- TODO rename to SimpleHost
 -- |
@@ -8,81 +9,101 @@
 --   This module contains reflex host methods for testing without external events
 
 module Reflex.Test.Monad.Host
-  ( AppIn(..)
-  , AppOut(..)
-  , AppFrame(..)
-  , getAppFrame
-  , tickAppFrame
-  , runAppSimple
-  , runApp
-  , runApp'
-  , runAppB
+  (
   )
 where
 
 import           Prelude
 
+
+import           Control.Concurrent.Chan   (newChan, readChan, writeChan)
+import           Control.Monad.IO.Class
+
+import qualified Control.Applicative       (liftA2)
+import           Control.Lens              (over, _2)
 import           Control.Monad
+import           Control.Monad.Fix
 import           Control.Monad.Ref
+import           Control.Monad.Trans.Class
 import           Data.Dependent.Sum
 import           Data.Functor.Identity
-import           Data.Maybe            (fromJust)
+import           Data.Maybe                (fromJust)
 import           Data.These
 
 import           Reflex
 import           Reflex.Host.Class
+import           Reflex.Spider.Internal    (HasSpiderTimeline)
+
+type TestGuestConstraints t (m :: * -> *) =
+  ( MonadReflexHost t m
+  , MonadHold t m
+  , MonadSample t m
+  , Ref m ~ Ref IO
+  , MonadRef (HostFrame t)
+  , Ref (HostFrame t) ~ Ref IO
+  , MonadIO (HostFrame t)
+  --, PrimMonad (HostFrame t)
+  , MonadIO m
+  , MonadFix m
+  )
 
 
-class MonadReflexTest m inh out where
+class MonadReflexTest t inh out m m' where
   inputEventHandles :: m inh -- ^ reads input event handles for use in calls to queueEvent
   queueEventTrigger :: DSum (EventTrigger t) Identity -> m ()
   outputs :: m out
+  -- readphase takes place in the inner monad
+  fireQueuedEventsAndRead :: ReadPhase m' a -> m [a]
+  -- TODO consider adding "firePostBuildAndRead" which isn't great because it's a required setup step for the user and makes monads less composable
+  -- another option is to hack it so first call to fireQUeuedEventsAndRead does PostBuild stuff...
 
-  -- TODO seems like you need to do fireQueuedEventsAndRead all at once :(
-  -- this means you don't get postbuild stuff unless you do something hacky like first call to this does postbuild...
-  readOutput :: ReadPhase (SpiderHost t) a -> m a
-  fireQueuedEvents :: m ()
+-- m is inner monad
+data AppState t m = AppState
+    { _appState_queuedEvents :: [DSum (EventTrigger t) Identity] -- ^ events to fire in next 'FireCommand'
+    -- ^ 'FireCommand' to fire events and run next frame
+    , _appState_fire         :: FireCommand t m -- ^ 'FireCommand' to fire events and run next frame
+    }
 
-data AppState t = AppState {
-  _appState_queuedEvents :: [DSum (EventTrigger t) Identity] -- ^ events to fire in next 'FireCommand'
-  , _appState_fire :: FireCommand t (SpiderHost t) -- ^ 'FireCommand' to fire events and run next frame
+newtype ReflexTestM t inh out m a = ReflexTestM { unReflexTestM :: (inh, out) -> AppState t m -> m (AppState t m, a) }
 
-  -- TODO DELETE won't work, each call to readPhase fires events again
-  , _appState_readPhase :: forall a. ReadPhase (SpiderHost t) a -> SpiderHost t a -- ^ method to execute 'ReadPhase' from previous 'FireCommand' or from 'PostBuild' if no previously fired events
-}
+instance MonadTrans (ReflexTestM t inh out) where
+  lift m = ReflexTestM $ \_ as -> fmap (\a -> (as,a)) m
 
-newtype ReflexTestM inh out t a = ReflexTestM { unReflexTestM :: (inh, out) -> AppState t -> SpiderHost t (AppState t, a) }
+instance (Functor m) => Functor (ReflexTestM t inh out m) where
+  fmap f ma = ReflexTestM $ \io as -> fmap (\(as',a) -> (as', f a)) $ unReflexTestM ma io as
 
-instance Functor (ReflexTestM inh out t) where
-  fmap f ma = ReflexTestM $ \io as -> over _2 (fmap f) $ unReflexTestM ma io as
+instance (Applicative m, Monad m) => Applicative (ReflexTestM t inh out m) where
+  pure a = ReflexTestM $ \_ as -> pure (as, a)
+  liftA2 f ma mb = ReflexTestM $ \io as0 -> do
+    -- TODO rewrite this using liftA2 and drop the Monad constraint
+    (as1, a) <- unReflexTestM ma io as0
+    (as2, b) <- unReflexTestM mb io as1
+    pure (as2, f a b)
 
-instance Applicative (ReflexTestM inh out t) where
-  pure a = ReflexTestM $ \_ as -> return (as, a)
-  liftA2 f ma mb = ReflexTestM $ \io as0 -> r where
-    (as1, a) = unReflexTestM ma io as0
-    (as2, b) = unReflexTestM mb io as1
-    r = return (as2, f a b)
+instance (Monad m) => Monad (ReflexTestM t inh out m) where
+  (>>=) ma f = ReflexTestM $ \io as0 -> do
+    (as1, a) <- unReflexTestM ma io as0
+    unReflexTestM (f a) io as1
 
-instance Monad (ReflexTestM inh out t) where
-  (>>=) ma f = ReflexTestM $ \io as0 -> r where
-    (as1, a) = unReflexTestM ma io as0
-    r = unReflexTestM (f a) io as1
-
-instance MonadReflexTest (ReflexTestM inh in out t m) inh out where
+instance (Monad m') => MonadReflexTest t inh out (ReflexTestM t inh out m') m' where
   inputEventHandles = ReflexTestM $ \(inh,_) as -> return (as, inh)
   queueEventTrigger evt = ReflexTestM $ \_ as -> return (as { _appState_queuedEvents = evt : _appState_queuedEvents as}, ())
   outputs = ReflexTestM $ \(_,out) as -> return (as, out)
-  readOutput rp = ReflexTestM $ \_ as -> fmap (as,) $ _appState_readPhase as rp
-  fireQueuedEvents = ReflexTestM $ \_ as -> return (as { _appState_readPhase = _appState_fire as (_appState_queuedEvents as) }, ())
+  fireQueuedEventsAndRead rp = ReflexTestM $ \_ as -> fmap (as,) $ (runFireCommand $ _appState_fire as) (_appState_queuedEvents as) rp
 
 
-runReflexTestM ::
-  ReflextTestM inh in out t m a
-  -> (inh, in) -- ^ make sure inh match inputs, i.e. return values of newEventWithTriggerRef
-  -> (in -> TriggerEventT (PostBuildT (PerformEventT t m out)))
-  -> IO a
-runReflexTestM rtm (inputH, input) app = do
+
+--HasSpiderTimeline x => MonadReflexCreateTrigger (SpiderTimeline x) (SpiderHost x)
+--newEventWithTriggerRef :: (MonadReflexCreateTrigger t m, MonadRef m, Ref m ~ Ref IO) => m (Event t a, Ref m (Maybe (EventTrigger t a)))
+
+runReflexTestM :: (forall t m. ReflexTestM t inh out m a)
+  -> (inh, inev) -- ^ make sure inh match inputs, i.e. return values of newEventWithTriggerRef
+  -> (forall t m. (TestGuestConstraints t m) => inev -> TriggerEventT t (PostBuildT t (PerformEventT t m)) out)
+  -> IO ()
+runReflexTestM rtm (inputH, input) app = withSpiderTimeline $ runSpiderHostForTimeline $ do
   (postBuild, postBuildTriggerRef) <- newEventWithTriggerRef
+  return ()
+
   events <- liftIO newChan
   (output, fc@(FireCommand fire)) <- do
     hostPerformEventT $
@@ -91,9 +112,9 @@ runReflexTestM rtm (inputH, input) app = do
           app input
 
   mPostBuildTrigger <- readRef postBuildTriggerRef
-  rp0 <- case mPostBuildTrigger of
-    Nothing -> error "could not create PostBuild trigger ref"
-    Just postBuildTrigger -> fire [postBuildTrigger :=> Identity ()]
+  _ <- case mPostBuildTrigger of
+    Nothing               -> error "could not create PostBuild trigger ref"
+    Just postBuildTrigger -> fire [postBuildTrigger :=> Identity ()] $ return ()
 
 
   -- TODO figure out how to do this
@@ -102,14 +123,16 @@ runReflexTestM rtm (inputH, input) app = do
   -- another option is just to start a thread and output warnings anytime triggerEvs are created
   --triggerEvs <- liftIO $ readChan events
 
-  unReflexTestM rtm (inputH, output) (AppState [] fc rp0)
+  unReflexTestM rtm (inputH, output) (AppState [] fc)
+  return ()
 
 
+{-
+class ReflexTestApp inh inev out app t m where
+  testApp :: inev -> TriggerEventT t (PostBuildT t (PerformEventT t m)) out
+  makeInputs :: SpiderHost t (inh, inev)
 
 
-class ReflexTestApp inh in out app t m where
-  testApp :: in -> TriggerEventT (PostBuildT (PerformEventT t m out))
-  makeInputs :: SpiderHost t (inh, in)
-
-
-runReflexTestApp :: (ReflexTestApp inh in out app t m a) =>
+runReflexTestApp :: (ReflexTestApp inh inev out app t m a) => ()
+runReflexTestApp = undefined
+-}

--- a/src/Reflex/Test/Monad/Host.hs
+++ b/src/Reflex/Test/Monad/Host.hs
@@ -115,7 +115,7 @@ instance MonadTrans (ReflexTestT t intref out) where
 instance (MonadSubscribeEvent t m) => MonadSubscribeEvent t (ReflexTestT t intref out m) where
   subscribeEvent = lift . subscribeEvent
 
-instance (Monad m, MonadRef m) => MonadReflexTest t (ReflexTestT t intref out m) where
+instance (MonadRef m) => MonadReflexTest t (ReflexTestT t intref out m) where
   type InputTriggerRefs (ReflexTestT t intref out m) = intref
   type OutputEvents (ReflexTestT t intref out m) = out
   type InnerMonad (ReflexTestT t intref out m) = m
@@ -164,7 +164,6 @@ runReflexTestT (input, inputTRefs) app rtm = do
     Just postBuildTrigger ->
       fire [postBuildTrigger :=> Identity ()] $ return ()
 
-
   -- TODO maybe find a way to handle trigger events
   -- one solution is to implement non-blocking variant of TriggerEventT
   -- and then pass as part of AppState such that each call to readPhase will fire any trigger events
@@ -175,8 +174,6 @@ runReflexTestT (input, inputTRefs) app rtm = do
   flip runStateT (AppState [] fc)
     $ flip runReaderT (inputTRefs, output)
       $ unReflexTestM rtm
-
-
 
   return ()
 

--- a/src/Reflex/Test/Monad/Host.hs
+++ b/src/Reflex/Test/Monad/Host.hs
@@ -13,7 +13,7 @@ module Reflex.Test.Monad.Host
   , TestGuestConstraints
   , MonadReflexTest(..)
   , AppState(..)
-  , ReflexTestM(..)
+  , ReflexTestT(..)
   , runReflexTestM
   )
 where
@@ -23,6 +23,9 @@ import           Prelude
 
 import           Control.Concurrent.Chan
 import           Control.Monad.IO.Class
+
+import Control.Monad.Reader
+import Control.Monad.State
 
 import qualified Control.Applicative       (liftA2)
 import           Control.Monad.Fix
@@ -85,58 +88,45 @@ data AppState t m = AppState
     }
 
 -- | implementation of 'MonadReflexTest'
-newtype ReflexTestM t mintref out m a = ReflexTestM { unReflexTestM :: (mintref, out) -> AppState t m -> m (AppState t m, a) }
+newtype ReflexTestT t mintref out m a = ReflexTestT { unReflexTestM :: ReaderT (mintref, out) (StateT (AppState t m) m) a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadReader (mintref, out), MonadState (AppState t m))
 
-instance MonadTrans (ReflexTestM t mintref out) where
-  lift m = ReflexTestM $ \_ as -> fmap (\a -> (as, a)) m
+instance MonadTrans (ReflexTestT t mintref out) where
+  lift = ReflexTestT . lift . lift
 
-instance (Functor m) => Functor (ReflexTestM t mintref out m) where
-  fmap f ma = ReflexTestM
-    $ \io as -> fmap (\(as', a) -> (as', f a)) $ unReflexTestM ma io as
-
-instance (Applicative m, Monad m) => Applicative (ReflexTestM t mintref out m) where
-  pure a = ReflexTestM $ \_ as -> pure (as, a)
-  liftA2 f ma mb = ReflexTestM $ \io as0 -> do
-    -- TODO rewrite this using liftA2 and drop the Monad constraint
-    (as1, a) <- unReflexTestM ma io as0
-    (as2, b) <- unReflexTestM mb io as1
-    pure (as2, f a b)
-
-instance (Monad m) => Monad (ReflexTestM t mintref out m) where
-  (>>=) ma f = ReflexTestM $ \io as0 -> do
-    (as1, a) <- unReflexTestM ma io as0
-    unReflexTestM (f a) io as1
-
-instance (MonadSubscribeEvent t m) => MonadSubscribeEvent t (ReflexTestM t mintref out m) where
+instance (MonadSubscribeEvent t m) => MonadSubscribeEvent t (ReflexTestT t mintref out m) where
   subscribeEvent = lift . subscribeEvent
 
-instance (MonadIO m) => MonadIO (ReflexTestM t mintref out m) where
-  liftIO = lift . liftIO
-
-instance (Monad m, MonadRef m) => MonadReflexTest t (ReflexTestM t mintref out m) where
-  type InputTriggerRefs (ReflexTestM t mintref out m) = mintref
-  type OutputEvents (ReflexTestM t mintref out m) = out
-  type InnerMonad (ReflexTestM t mintref out m) = m
-  inputTriggerRefs = ReflexTestM $ \(mintref, _) as -> return (as, mintref)
-  queueEventTrigger evt = ReflexTestM $ \_ as -> return
-    (as { _appState_queuedEvents = evt : _appState_queuedEvents as }, ())
-  queueEventTriggerRef ref a = ReflexTestM $ \_ as -> do
-    mpulse <- readRef ref
+instance (Monad m, MonadRef m) => MonadReflexTest t (ReflexTestT t mintref out m) where
+  type InputTriggerRefs (ReflexTestT t mintref out m) = mintref
+  type OutputEvents (ReflexTestT t mintref out m) = out
+  type InnerMonad (ReflexTestT t mintref out m) = m
+  inputTriggerRefs = do
+    (mintref,_) <- ask
+    return mintref
+  queueEventTrigger evt = do
+    as <- get 
+    put $ as { _appState_queuedEvents = evt : _appState_queuedEvents as }
+  queueEventTriggerRef ref a = do
+    mpulse <- lift $ readRef ref
     case mpulse of
-      Nothing    -> return (as, ())
-      Just pulse -> return
-        (as { _appState_queuedEvents = (pulse :=> Identity a) : _appState_queuedEvents as }, ())
-  outputs = ReflexTestM $ \(_, out) as -> return (as, out)
-  fireQueuedEventsAndRead rp = ReflexTestM $ \_ as ->
-    fmap (as, )
-      $ (runFireCommand $ _appState_fire as) (_appState_queuedEvents as) rp
+      Nothing    -> return ()
+      Just pulse -> do
+        as <- get
+        put $ as { _appState_queuedEvents = (pulse :=> Identity a) : _appState_queuedEvents as }
+  outputs = do
+    (_,out) <- ask 
+    return out
+  fireQueuedEventsAndRead rp = do
+    as <- get
+    lift $ (runFireCommand $ _appState_fire as) (_appState_queuedEvents as) rp
 
 runReflexTestM
   :: forall mintref inev out t m a
    . (TestGuestConstraints t m)
   => (inev, mintref) -- ^ make sure mintref match inev, i.e. return values of newEventWithTriggerRef
   -> (inev -> TestGuestT t m out) -- ^ network to test
-  -> ReflexTestM t mintref out m a -- ^ test monad to run
+  -> ReflexTestT t mintref out m a -- ^ test monad to run
   -> m ()
 runReflexTestM (input, inputTRefs) app rtm = do
   (postBuild, postBuildTriggerRef) <- newEventWithTriggerRef
@@ -164,13 +154,17 @@ runReflexTestM (input, inputTRefs) app rtm = do
   --triggerEvs <- liftIO $ readChan events
 
   -- run the test monad
-  unReflexTestM rtm (inputTRefs, output) (AppState [] fc)
+  flip runStateT (AppState [] fc)
+    $ flip runReaderT (inputTRefs, output) 
+      $ unReflexTestM rtm 
+    
+   
 
   return ()
 
 
 
--- | class to help bind network and types to a 'ReflexTestM'
+-- | class to help bind network and types to a 'ReflexTestT'
 -- TODO write an example using this
 class ReflexTestApp app t m | app -> t m where
   data AppInputTriggerRefs app :: Type
@@ -180,11 +174,11 @@ class ReflexTestApp app t m | app -> t m where
   makeInputs :: m (AppInputEvents app, AppInputTriggerRefs app)
 -- TODO to simplify MonadReflexTest interface, maybe we could do something like
 -- subscribeEventsAndReturnTriggers :: m (AppInputTriggers app)
--- and then change (InputTriggerRefs (ReflexTestM ...)) to just (InputTrigger (ReflexTestM ...))
+-- and then change (InputTriggerRefs (ReflexTestT ...)) to just (InputTrigger (ReflexTestT ...))
 
 runReflexTestApp
   :: (ReflexTestApp app t m, TestGuestConstraints t m)
-  => ReflexTestM t (AppInputTriggerRefs app) (AppOutput app) m ()
+  => ReflexTestT t (AppInputTriggerRefs app) (AppOutput app) m ()
   -> m ()
 runReflexTestApp rtm = do
   i <- makeInputs

--- a/test/Reflex/Test/HostSpec.hs
+++ b/test/Reflex/Test/HostSpec.hs
@@ -9,16 +9,16 @@ where
 import           Prelude
 
 import           Test.Hspec
-import           Test.Hspec.Contrib.HUnit (fromHUnitTest)
+import           Test.Hspec.Contrib.HUnit       ( fromHUnitTest )
 import           Test.HUnit
 
 import           Reflex
 import           Reflex.Test.Host
 
-import           Control.Monad            (forM_)
-import           Control.Monad.IO.Class   (liftIO)
+import           Control.Monad                  ( forM_ )
+import           Control.Monad.IO.Class         ( liftIO )
 import           Data.Functor
-import qualified Data.List                as L
+import qualified Data.List                     as L
 import           Data.These
 
 
@@ -26,7 +26,7 @@ import           Data.These
 postbuild_network
   :: forall t m
    . (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (AppIn t () () -> TestGuestMonad t m (AppOut t Bool ()))
+  => (AppIn t () () -> TestGuestT t m (AppOut t Bool ()))
 postbuild_network AppIn {..} = do
   pbev            <- getPostBuild
   didPBTriggerBeh <- hold False (pbev $> True)
@@ -45,7 +45,7 @@ test_postbuild = TestLabel "postbuild" $ TestCase $ runSpiderHost $ do
 basic_network
   :: forall t m
    . (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (AppIn t Int Int -> TestGuestMonad t m (AppOut t Int Int))
+  => (AppIn t Int Int -> TestGuestT t m (AppOut t Int Int))
 basic_network AppIn {..} = return AppOut
   { _appOut_behavior = fmap (* (-1)) _appIn_behavior
   , _appOut_event    = fmap (\(b, e) -> e + b)

--- a/test/Reflex/Test/HostSpec.hs
+++ b/test/Reflex/Test/HostSpec.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE RankNTypes      #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Reflex.Test.HostSpec
   ( spec
@@ -9,15 +9,15 @@ where
 import           Prelude
 
 import           Test.Hspec
-import           Test.Hspec.Contrib.HUnit       ( fromHUnitTest )
+import           Test.Hspec.Contrib.HUnit (fromHUnitTest)
 import           Test.HUnit
 
 import           Reflex
 import           Reflex.Test.Host
 
-import           Control.Monad                  ( forM_ )
-import           Control.Monad.IO.Class         ( liftIO )
-import qualified Data.List                     as L
+import           Control.Monad            (forM_)
+import           Control.Monad.IO.Class   (liftIO)
+import qualified Data.List                as L
 import           Data.These
 
 
@@ -42,5 +42,5 @@ test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
     liftIO $ L.last out @?= (-b, Just (b + e))
 
 spec :: Spec
-spec = describe "Reflex.Test.App" $ do
+spec = do
   fromHUnitTest test_basic

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE RankNTypes      #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Reflex.Test.Monad.HostSpec
   ( spec
@@ -13,21 +14,24 @@ import           Test.Hspec.Contrib.HUnit (fromHUnitTest)
 import           Test.HUnit
 
 import           Control.Monad.IO.Class   (liftIO)
-import           Control.Monad.Ref
-import           Data.Dependent.Sum
-import           Data.Functor.Identity
+import           Data.Kind
 
 import           Reflex
 import           Reflex.Host.Class
 import           Reflex.Test.Monad.Host
 
 
-type T = SpiderTimeline Global
+{-
+class ReflexTestApp app t m | app -> t m where
+  data AppInputTriggerRefs app :: Type
+  data AppInputEvents app :: Type
+  data AppOutput app :: Type
+  getApp :: AppInputEvents app -> TestGuestT t m (AppOutput app)
+  makeInputs :: m (AppInputEvents app, AppInputTriggerRefs app)
+-}
 
 -- | a very basic test network, simple passes on the input event to its observed outputs
-basic_network
-  :: forall t m
-   . (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
+basic_network :: forall t m. (ReflexHost t)
   => (Event t Int -> TestGuestT t m (Event t Int))
 basic_network ev = return ev
 
@@ -42,7 +46,7 @@ test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
     -- get our input trigger ref, dereference it, queue it and fire it
     intref                           <- inputTriggerRefs
 
-    -- old version which manually dereferences our input trigger
+    -- example of how to manually dereferences our input trigger
     {-
     mh :: Maybe (EventTrigger T Int) <- liftIO $ readRef intref
     case mh of
@@ -51,16 +55,48 @@ test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
     -}
 
     -- simpler version that uses 'queueEventTriggerRef'
-    queueEventTriggerRef intref 0
+    queueEventTriggerRef intref 123
 
     -- fire the events and read from our output handle
     a <- fireQueuedEventsAndRead $ sequence =<< readEvent oh
 
     -- validate results
-    liftIO $ a @?= [Just 0]
+    liftIO $ a @?= [Just 123]
 
+data BasicNetworkTest1 t (m :: Type -> Type)
+
+instance (TestGuestConstraints t m) => ReflexTestApp (BasicNetworkTest1 t m) t m where
+  data AppInputTriggerRefs (BasicNetworkTest1 t m) =
+    BasicNetworkTest1_InputTriggerRefs { _basicNetworkTest1_InputTriggerRefs_intEvTRef :: ReflexTriggerRef t m Int }
+  data AppInputEvents (BasicNetworkTest1 t m) =
+    BasicNetworkTest1_InputEvents { _basicNetworkTest1_InputEvents_intEv :: Event t Int }
+  data AppOutput (BasicNetworkTest1 t m) =
+    BasicNetworkTest1_Output { _basicNetworkTest1_Output_intEv :: Event t Int }
+  getApp ev = basic_network (_basicNetworkTest1_InputEvents_intEv ev) >>= return . BasicNetworkTest1_Output
+  makeInputs = do
+    (inev, intref) <- newEventWithTriggerRef
+    return (BasicNetworkTest1_InputEvents inev, BasicNetworkTest1_InputTriggerRefs intref)
+
+test_basic_viaReflexTestApp :: Test
+test_basic_viaReflexTestApp = TestLabel "basic_viaReflexTestApp" $ TestCase $ runSpiderHost $
+  runReflexTestApp @ (BasicNetworkTest1 (SpiderTimeline Global) (SpiderHost Global)) $ do
+    -- get our app's output events and subscribe to them
+    BasicNetworkTest1_Output {..} <- outputs
+    oh                            <- subscribeEvent _basicNetworkTest1_Output_intEv
+    -- get our input trigger ref, dereference it, queue it and fire it
+    BasicNetworkTest1_InputTriggerRefs{..}                           <- inputTriggerRefs
+
+    -- simpler version that uses 'queueEventTriggerRef'
+    queueEventTriggerRef _basicNetworkTest1_InputTriggerRefs_intEvTRef 123
+
+    -- fire the events and read from our output handle
+    a <- fireQueuedEventsAndRead $ sequence =<< readEvent oh
+
+    -- validate results
+    liftIO $ a @?= [Just 123]
 
 
 spec :: Spec
 spec = do
   fromHUnitTest test_basic
+  fromHUnitTest test_basic_viaReflexTestApp

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -47,7 +47,7 @@ test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
       a <- fireQueuedEventsAndRead $ sequence =<< readEvent oh
       liftIO $ a @?= [Just 0]
 
-  liftIO $ runReflexTestM (minh, inev) basic_network testm
+  runReflexTestM (minh, inev) basic_network testm
 
 
 

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -33,21 +33,20 @@ basic_network ev = return ev
 
 test_basic :: Test
 test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
-  (inev, intref) <- newEventWithTriggerRef
-  minh <- readRef intref
+  ins <- newEventWithTriggerRef
   let
-    testm :: ReflexTestM T (Maybe (EventTrigger T Int)) (Event T Int) (SpiderHost Global) ()
     testm = do
       o <- outputs
       oh <- subscribeEvent o
-      mh :: Maybe (EventTrigger T Int) <- inputEventHandles
+      intref <- inputEventHandles
+      mh :: Maybe (EventTrigger T Int) <- liftIO $ readRef intref
       case mh of
         Just h  -> queueEventTrigger $ (h :=> Identity 0)
         Nothing -> error "no subscribers to h"
       a <- fireQueuedEventsAndRead $ sequence =<< readEvent oh
       liftIO $ a @?= [Just 0]
 
-  runReflexTestM (minh, inev) basic_network testm
+  runReflexTestM ins basic_network testm
 
 
 

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -39,7 +39,7 @@ basic_network ev = return ev
 test_basic :: Test
 test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
   ins <- newEventWithTriggerRef
-  runReflexTestM ins basic_network $ do
+  runReflexTestT ins basic_network $ do
 
     -- get our app's output events and subscribe to them
     oh                               <- subscribeEvent =<< outputs

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -28,9 +28,7 @@ type T = SpiderTimeline Global
 basic_network
   :: forall t m
    . (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (  Event t Int
-     -> TriggerEventT t (PostBuildT t (PerformEventT t m)) (Event t Int)
-     )
+  => (Event t Int -> TestGuestT t m (Event t Int))
 basic_network ev = return ev
 
 -- | test 'basic_network'

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -9,27 +9,28 @@ where
 import           Prelude
 
 import           Test.Hspec
-import           Test.Hspec.Contrib.HUnit (fromHUnitTest)
+import           Test.Hspec.Contrib.HUnit       ( fromHUnitTest )
 import           Test.HUnit
+
+import           Control.Monad.IO.Class         ( liftIO )
+import           Control.Monad.Ref
+import           Data.Dependent.Sum
+import           Data.Functor.Identity
 
 import           Reflex
 import           Reflex.Host.Class
 import           Reflex.Test.Monad.Host
-
-import           Control.Monad            (forM_)
-import           Control.Monad.IO.Class   (liftIO)
-import           Control.Monad.Ref
-import           Data.Dependent.Sum
-import           Data.Functor.Identity
-import           Data.Maybe
 
 
 type T = SpiderTimeline Global
 
 -- | a very basic test network, simple passes on the input event to its observed outputs
 basic_network
-  :: forall t m. (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
-  => (Event t Int -> TriggerEventT t (PostBuildT t (PerformEventT t m)) (Event t Int))
+  :: forall t m
+   . (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
+  => (  Event t Int
+     -> TriggerEventT t (PostBuildT t (PerformEventT t m)) (Event t Int)
+     )
 basic_network ev = return ev
 
 -- | test 'basic_network'
@@ -38,10 +39,10 @@ test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
   ins <- newEventWithTriggerRef
   runReflexTestM ins basic_network $ do
     -- get our app's output events and subscribe to them
-    oh <- subscribeEvent =<< outputs
+    oh                               <- subscribeEvent =<< outputs
 
     -- get our input trigger ref, dereference it, queue it and fire it
-    intref <- inputTriggerRefs
+    intref                           <- inputTriggerRefs
     mh :: Maybe (EventTrigger T Int) <- liftIO $ readRef intref
     case mh of
       Just h  -> queueEventTrigger $ (h :=> Identity 0)

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -9,10 +9,10 @@ where
 import           Prelude
 
 import           Test.Hspec
-import           Test.Hspec.Contrib.HUnit       ( fromHUnitTest )
+import           Test.Hspec.Contrib.HUnit (fromHUnitTest)
 import           Test.HUnit
 
-import           Control.Monad.IO.Class         ( liftIO )
+import           Control.Monad.IO.Class   (liftIO)
 import           Control.Monad.Ref
 import           Data.Dependent.Sum
 import           Data.Functor.Identity
@@ -36,15 +36,18 @@ test_basic :: Test
 test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
   ins <- newEventWithTriggerRef
   runReflexTestM ins basic_network $ do
+
     -- get our app's output events and subscribe to them
     oh                               <- subscribeEvent =<< outputs
-
     -- get our input trigger ref, dereference it, queue it and fire it
     intref                           <- inputTriggerRefs
+    {-
     mh :: Maybe (EventTrigger T Int) <- liftIO $ readRef intref
     case mh of
       Just h  -> queueEventTrigger $ (h :=> Identity 0)
       Nothing -> error "no subscribers to h"
+    -}
+    queueEventTriggerRef intref 0
     a <- fireQueuedEventsAndRead $ sequence =<< readEvent oh
 
     -- validate results

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE RankNTypes      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Reflex.Test.Monad.HostSpec
+  ( spec
+  )
+where
+
+import           Prelude
+
+import           Test.Hspec
+import           Test.Hspec.Contrib.HUnit (fromHUnitTest)
+import           Test.HUnit
+
+import           Reflex
+import           Reflex.Host.Class
+import           Reflex.Test.Monad.Host
+
+import           Control.Monad            (forM_)
+import           Control.Monad.IO.Class   (liftIO)
+import           Control.Monad.Ref
+import           Data.Dependent.Sum
+import           Data.Functor.Identity
+import           Data.Maybe
+
+
+type T = SpiderTimeline Global
+
+basic_network
+  :: forall t m. (t ~ SpiderTimeline Global, m ~ SpiderHost Global)
+  => (Event t Int -> TriggerEventT t (PostBuildT t (PerformEventT t m)) (Event t Int))
+basic_network ev = return ev
+
+test_basic :: Test
+test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
+  (inev, intref) <- newEventWithTriggerRef
+  minh <- readRef intref
+  let
+    testm :: ReflexTestM T (Maybe (EventTrigger T Int)) (Event T Int) (SpiderHost Global) ()
+    testm = do
+      o <- outputs
+      oh <- subscribeEvent o
+      mh :: Maybe (EventTrigger T Int) <- inputEventHandles
+      case mh of
+        Just h  -> queueEventTrigger $ (h :=> Identity 0)
+        Nothing -> error "no subscribers to h"
+      a <- fireQueuedEventsAndRead $ sequence =<< readEvent oh
+      liftIO $ a @?= [Just 0]
+
+  liftIO $ runReflexTestM (minh, inev) basic_network testm
+
+
+
+spec :: Spec
+spec = do
+  fromHUnitTest test_basic

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -21,15 +21,6 @@ import           Reflex.Host.Class
 import           Reflex.Test.Monad.Host
 
 
-{-
-class ReflexTestApp app t m | app -> t m where
-  data AppInputTriggerRefs app :: Type
-  data AppInputEvents app :: Type
-  data AppOutput app :: Type
-  getApp :: AppInputEvents app -> TestGuestT t m (AppOutput app)
-  makeInputs :: m (AppInputEvents app, AppInputTriggerRefs app)
--}
-
 -- | a very basic test network, simple passes on the input event to its observed outputs
 basic_network :: forall t m. (ReflexHost t)
   => (Event t Int -> TestGuestT t m (Event t Int))

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -41,13 +41,19 @@ test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
     oh                               <- subscribeEvent =<< outputs
     -- get our input trigger ref, dereference it, queue it and fire it
     intref                           <- inputTriggerRefs
+
+    -- old version which manually dereferences our input trigger
     {-
     mh :: Maybe (EventTrigger T Int) <- liftIO $ readRef intref
     case mh of
       Just h  -> queueEventTrigger $ (h :=> Identity 0)
       Nothing -> error "no subscribers to h"
     -}
+
+    -- simpler version that uses 'queueEventTriggerRef'
     queueEventTriggerRef intref 0
+
+    -- fire the events and read from our output handle
     a <- fireQueuedEventsAndRead $ sequence =<< readEvent oh
 
     -- validate results

--- a/test/Reflex/Test/Monad/HostSpec.hs
+++ b/test/Reflex/Test/Monad/HostSpec.hs
@@ -38,7 +38,7 @@ test_basic = TestLabel "basic" $ TestCase $ runSpiderHost $ do
     testm = do
       o <- outputs
       oh <- subscribeEvent o
-      intref <- inputEventHandles
+      intref <- inputTriggerRefs
       mh :: Maybe (EventTrigger T Int) <- liftIO $ readRef intref
       case mh of
         Just h  -> queueEventTrigger $ (h :=> Identity 0)


### PR DESCRIPTION
Basic sketch for reflex test monad.

The intent is to build host specific test monads on top of this.

Currently compiles and very simple test passes.

I'm pretty happy with the design except for one part. See comment on `InputTriggerRefs`

Monadic test is being in my existing test package. The monadic test module is entirely isolated so it's safe to ignore everything else in this repo.